### PR TITLE
Add multizone base path support

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from 'next';
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH !== undefined
+  ? process.env.NEXT_PUBLIC_BASE_PATH
+  : '/us/state-eitcs-ctcs';
+
+
 const nextConfig: NextConfig = {
+  ...(basePath ? { basePath } : {}),
+  env: { NEXT_PUBLIC_BASE_PATH: basePath },
   // Pin the workspace root so Turbopack does not silently pick up a stray
   // lockfile from a parent directory during local development or CI.
   turbopack: {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
     ],
   },
   icons: {
-    icon: '/favicon.svg',
+    icon: `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/favicon.svg`,
   },
 };
 


### PR DESCRIPTION
Adds a production base path for the PolicyEngine multizone mount and keeps local/root builds available with `NEXT_PUBLIC_BASE_PATH=` where the app uses Next.js.

Also prefixes root-relative public data/assets where needed so the zone loads correctly behind `policyengine.org` instead of only passing a framework build.

Verification:
- `git diff --check`