### PR TITLE
Fix mounted data asset paths

### DIFF
--- a/frontend/src/components/Masthead.tsx
+++ b/frontend/src/components/Masthead.tsx
@@ -46,7 +46,7 @@ export default function Masthead() {
           aria-label="Visit PolicyEngine"
         >
           <img
-            src="/policyengine-logo.svg"
+            src={`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/policyengine-logo.svg`}
             alt="PolicyEngine"
             style={styles.logoImg}
           />

--- a/frontend/src/data/useData.ts
+++ b/frontend/src/data/useData.ts
@@ -33,6 +33,15 @@ interface UseDataReturn {
   error: string | null;
 }
 
+function publicAssetPath(path: string): string {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+  const normalizedBasePath =
+    basePath === "/" ? "" : basePath.replace(/\/$/, "");
+  const normalizedPath = path.replace(/^\//, "");
+
+  return `${normalizedBasePath}/${normalizedPath}`;
+}
+
 function transformAlaska(
   coords: unknown,
   scale: number,
@@ -171,12 +180,9 @@ export function useData(): UseDataReturn {
 
     async function load() {
       try {
-        // Load GeoJSON files. Public assets are served from the site root
-        // under Next.js, so the base path is just "/".
-        const base = "/";
         const [stateGeoRes, districtGeoRes] = await Promise.all([
-          fetch(`${base}data/states_from_districts.geojson`),
-          fetch(`${base}data/real_congressional_districts.geojson`),
+          fetch(publicAssetPath("data/states_from_districts.geojson")),
+          fetch(publicAssetPath("data/real_congressional_districts.geojson")),
         ]);
 
         if (!stateGeoRes.ok || !districtGeoRes.ok) {
@@ -192,8 +198,8 @@ export function useData(): UseDataReturn {
         // Load all year-specific CSVs in parallel
         const yearPromises = SUPPORTED_YEARS.map(async (year: SupportedYear) => {
           const [stateRes, districtRes] = await Promise.all([
-            fetch(`${base}data/state_impacts_${year}.csv`),
-            fetch(`${base}data/district_impacts_${year}.csv`),
+            fetch(publicAssetPath(`data/state_impacts_${year}.csv`)),
+            fetch(publicAssetPath(`data/district_impacts_${year}.csv`)),
           ]);
 
           if (!stateRes.ok || !districtRes.ok) {

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -51,6 +51,8 @@ const mockGeoJSON = {
 };
 
 beforeEach(() => {
+  delete process.env.NEXT_PUBLIC_BASE_PATH;
+
   globalThis.fetch = vi.fn().mockImplementation((url: string) => {
     if (url.includes("state_impacts")) {
       return Promise.resolve({
@@ -107,5 +109,26 @@ describe("App", () => {
     await waitFor(() => {
       expect(screen.getByText(/Error loading data/)).toBeInTheDocument();
     });
+  });
+
+  it("prefixes public data requests with the Next base path", async () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/us/state-eitcs-ctcs";
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        "/us/state-eitcs-ctcs/data/states_from_districts.geojson",
+      );
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/us/state-eitcs-ctcs/data/real_congressional_districts.geojson",
+    );
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/us/state-eitcs-ctcs/data/state_impacts_2025.csv",
+    );
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/us/state-eitcs-ctcs/data/district_impacts_2026.csv",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Prefix public data fetches with `NEXT_PUBLIC_BASE_PATH` so the multizone deployment requests `/us/state-eitcs-ctcs/data/...`.
- Prefix the masthead logo asset with `NEXT_PUBLIC_BASE_PATH`.
- Keep root deployments working when `NEXT_PUBLIC_BASE_PATH` is unset or empty.
- Add a regression test for the mounted-path data requests.

## Root Cause

PR #17 configured the Next base path, but `frontend/src/data/useData.ts` still hardcoded public data requests to `/data/...`. On `policyengine.org/us/state-eitcs-ctcs`, those root data URLs 404 while the mounted data URLs return 200. The masthead logo also used a root asset URL.

## Verification

- `npm run test`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `curl http://localhost:3020/us/state-eitcs-ctcs/data/states_from_districts.geojson` returns 200
- `curl https://www.policyengine.org/us/state-eitcs-ctcs/data/states_from_districts.geojson` returns 200; `/data/states_from_districts.geojson` returns 404
- Follow-up audit across local multizone checkouts reports zero remaining root-relative runtime risk hits
