### PR TITLE
Show poverty rate levels and pp changes alongside percent reductions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,7 +96,15 @@ export default function App() {
 
   const stats = useMemo(() => {
     if (nationalDistrictData.length === 0)
-      return { totalCost: 0, povertyReduction: 0, childPovertyReduction: 0 };
+      return {
+        totalCost: 0,
+        povertyReduction: 0,
+        childPovertyReduction: 0,
+        baselineRate: 0,
+        reformRate: 0,
+        baselineChildRate: 0,
+        reformChildRate: 0,
+      };
 
     const totalCost = nationalDistrictData.reduce(
       (sum, d) => sum + (d.cost || 0),
@@ -130,7 +138,15 @@ export default function App() {
     const childPovertyReduction = reformChildRate > 0
       ? (reformChildRate - baselineChildRate) / reformChildRate : 0;
 
-    return { totalCost, povertyReduction, childPovertyReduction };
+    return {
+      totalCost,
+      povertyReduction,
+      childPovertyReduction,
+      baselineRate,
+      reformRate,
+      baselineChildRate,
+      reformChildRate,
+    };
   }, [nationalDistrictData]);
 
   const regionData = useMemo(() => {
@@ -150,6 +166,12 @@ export default function App() {
       cost: row.cost as number,
       poverty_pct_cut: row.poverty_pct_cut as number,
       child_poverty_pct_cut: row.child_poverty_pct_cut as number,
+      poverty_pp_cut: row.poverty_pp_cut as number,
+      child_poverty_pp_cut: row.child_poverty_pp_cut as number,
+      baseline_poverty_rate: row.baseline_poverty_rate as number,
+      reform_poverty_rate: row.reform_poverty_rate as number,
+      baseline_child_poverty_rate: row.baseline_child_poverty_rate as number,
+      reform_child_poverty_rate: row.reform_child_poverty_rate as number,
     };
   }, [selectedRegion, filteredData, viewType]);
 
@@ -204,6 +226,10 @@ export default function App() {
           totalCost={stats.totalCost}
           povertyReduction={stats.povertyReduction}
           childPovertyReduction={stats.childPovertyReduction}
+          baselineRate={stats.baselineRate}
+          reformRate={stats.reformRate}
+          baselineChildRate={stats.baselineChildRate}
+          reformChildRate={stats.reformChildRate}
         />
       )}
       <main style={styles.mainContent}>

--- a/frontend/src/components/DetailPanel.tsx
+++ b/frontend/src/components/DetailPanel.tsx
@@ -7,6 +7,12 @@ interface RegionData {
   cost: number;
   poverty_pct_cut: number;
   child_poverty_pct_cut: number;
+  poverty_pp_cut: number;
+  child_poverty_pp_cut: number;
+  baseline_poverty_rate: number;
+  reform_poverty_rate: number;
+  baseline_child_poverty_rate: number;
+  reform_child_poverty_rate: number;
 }
 
 interface DetailPanelProps {
@@ -91,7 +97,28 @@ const styles: Record<string, CSSProperties> = {
     fontWeight: 600,
     color: "var(--success)",
   },
+  metricSubtext: {
+    fontFamily: "'Inter', sans-serif",
+    fontSize: 12,
+    color: "var(--slate-400)",
+    marginTop: 2,
+  },
 };
+
+/** For the pp metrics, show the underlying rate movement: without the
+ *  credit (repeal counterfactual) → with it (current law). */
+function rateSubtext(
+  regionData: RegionData,
+  key: string,
+): string | null {
+  if (key === "poverty_pp_cut") {
+    return `${formatValue(regionData.reform_poverty_rate, "percent")} without → ${formatValue(regionData.baseline_poverty_rate, "percent")} with credit`;
+  }
+  if (key === "child_poverty_pp_cut") {
+    return `${formatValue(regionData.reform_child_poverty_rate, "percent")} without → ${formatValue(regionData.baseline_child_poverty_rate, "percent")} with credit`;
+  }
+  return null;
+}
 
 export default function DetailPanel({
   selectedRegion,
@@ -160,7 +187,9 @@ export default function DetailPanel({
       <div style={styles.metrics}>
         {METRICS.map((m, i) => {
           const value = regionData[m.key as keyof RegionData];
-          const isPositivePercent = m.format === "percent" && value > 0;
+          const isPositivePercent =
+            (m.format === "percent" || m.format === "pp") && value > 0;
+          const subtext = rateSubtext(regionData, m.key);
           return (
             <div
               key={m.key}
@@ -170,7 +199,10 @@ export default function DetailPanel({
                   : styles.metricRow
               }
             >
-              <span style={styles.metricLabel}>{m.label}</span>
+              <span style={styles.metricLabel}>
+                {m.label}
+                {subtext && <div style={styles.metricSubtext}>{subtext}</div>}
+              </span>
               <span
                 style={
                   isPositivePercent

--- a/frontend/src/components/StatsBanner.tsx
+++ b/frontend/src/components/StatsBanner.tsx
@@ -5,6 +5,10 @@ interface StatsBannerProps {
   totalCost: number;
   povertyReduction: number;
   childPovertyReduction: number;
+  baselineRate: number;
+  reformRate: number;
+  baselineChildRate: number;
+  reformChildRate: number;
 }
 
 const styles: Record<string, CSSProperties> = {
@@ -65,7 +69,16 @@ export default function StatsBanner({
   totalCost,
   povertyReduction,
   childPovertyReduction,
+  baselineRate,
+  reformRate,
+  baselineChildRate,
+  reformChildRate,
 }: StatsBannerProps) {
+  // Without the credits the rate would be the reform (repeal) rate; with
+  // them it is the baseline rate — show the level change alongside the
+  // percent reduction.
+  const rateContext = (withCredit: number, withoutCredit: number) =>
+    `${formatValue(withoutCredit, "percent")} → ${formatValue(withCredit, "percent")} (−${formatValue(withoutCredit - withCredit, "pp")})`;
   const stats = [
     {
       eyebrow: "Total Investment",
@@ -75,12 +88,12 @@ export default function StatsBanner({
     {
       eyebrow: "Poverty Reduction",
       value: formatValue(povertyReduction, "percent"),
-      context: "national decrease",
+      context: rateContext(baselineRate, reformRate),
     },
     {
       eyebrow: "Child Poverty Reduction",
       value: formatValue(childPovertyReduction, "percent"),
-      context: "national decrease",
+      context: rateContext(baselineChildRate, reformChildRate),
     },
   ];
 

--- a/frontend/src/components/Visualization.tsx
+++ b/frontend/src/components/Visualization.tsx
@@ -16,6 +16,12 @@ interface VisualizationProps {
     cost: number;
     poverty_pct_cut: number;
     child_poverty_pct_cut: number;
+    poverty_pp_cut: number;
+    child_poverty_pp_cut: number;
+    baseline_poverty_rate: number;
+    reform_poverty_rate: number;
+    baseline_child_poverty_rate: number;
+    reform_child_poverty_rate: number;
   } | null;
   onRegionClick: (region: { id: string | number; name: string }) => void;
 }

--- a/frontend/src/data/useData.ts
+++ b/frontend/src/data/useData.ts
@@ -166,6 +166,48 @@ function transformDistrictGeo(geoJson: GeoJSON): GeoJSON {
   return { type: "FeatureCollection", features };
 }
 
+/** Derive poverty rates and percentage-point cuts from the CSVs' weighted
+ *  count columns. Rates are fractions of the (child) population; the pp cut
+ *  is baseline rate minus reform rate, so positive means the credit lowers
+ *  poverty — the same "bigger is better" orientation as the pct_cut columns. */
+export interface DerivedRates {
+  baseline_poverty_rate: number;
+  reform_poverty_rate: number;
+  poverty_pp_cut: number;
+  baseline_child_poverty_rate: number;
+  reform_child_poverty_rate: number;
+  child_poverty_pp_cut: number;
+}
+
+export function withDerivedRates<
+  T extends {
+    baseline_poverty_count: number;
+    reform_poverty_count: number;
+    population: number;
+    baseline_child_poverty_count: number;
+    reform_child_poverty_count: number;
+    child_population: number;
+  },
+>(row: T): T & DerivedRates {
+  const pop = row.population || 0;
+  const childPop = row.child_population || 0;
+  const baselineRate = pop > 0 ? (row.baseline_poverty_count || 0) / pop : 0;
+  const reformRate = pop > 0 ? (row.reform_poverty_count || 0) / pop : 0;
+  const baselineChildRate =
+    childPop > 0 ? (row.baseline_child_poverty_count || 0) / childPop : 0;
+  const reformChildRate =
+    childPop > 0 ? (row.reform_child_poverty_count || 0) / childPop : 0;
+  return {
+    ...row,
+    baseline_poverty_rate: baselineRate,
+    reform_poverty_rate: reformRate,
+    poverty_pp_cut: baselineRate - reformRate,
+    baseline_child_poverty_rate: baselineChildRate,
+    reform_child_poverty_rate: reformChildRate,
+    child_poverty_pp_cut: baselineChildRate - reformChildRate,
+  };
+}
+
 export function useData(): UseDataReturn {
   const [dataByYear, setDataByYear] = useState<Record<number, DataByYear>>({});
   const [stateGeoData, setStateGeoData] = useState<GeoJSON | null>(null);
@@ -211,8 +253,9 @@ export function useData(): UseDataReturn {
 
           return {
             year,
-            stateData: parseCSV<StateResult>(stateText),
-            districtData: parseCSV<DistrictResult>(districtText),
+            stateData: parseCSV<StateResult>(stateText).map(withDerivedRates),
+            districtData:
+              parseCSV<DistrictResult>(districtText).map(withDerivedRates),
           };
         });
 

--- a/frontend/src/data/useData.ts
+++ b/frontend/src/data/useData.ts
@@ -167,9 +167,11 @@ function transformDistrictGeo(geoJson: GeoJSON): GeoJSON {
 }
 
 /** Derive poverty rates and percentage-point cuts from the CSVs' weighted
- *  count columns. Rates are fractions of the (child) population; the pp cut
- *  is baseline rate minus reform rate, so positive means the credit lowers
- *  poverty — the same "bigger is better" orientation as the pct_cut columns. */
+ *  count columns. Rates are fractions of the (child) population. "Reform"
+ *  here is the credit's REPEAL, so the pp cut is reform rate minus baseline
+ *  rate — how much higher poverty would be without the credit. Positive
+ *  means the credit lowers poverty, the same orientation as pct_cut
+ *  (= (reform − baseline) / reform in the pipeline). */
 export interface DerivedRates {
   baseline_poverty_rate: number;
   reform_poverty_rate: number;
@@ -201,10 +203,10 @@ export function withDerivedRates<
     ...row,
     baseline_poverty_rate: baselineRate,
     reform_poverty_rate: reformRate,
-    poverty_pp_cut: baselineRate - reformRate,
+    poverty_pp_cut: reformRate - baselineRate,
     baseline_child_poverty_rate: baselineChildRate,
     reform_child_poverty_rate: reformChildRate,
-    child_poverty_pp_cut: baselineChildRate - reformChildRate,
+    child_poverty_pp_cut: reformChildRate - baselineChildRate,
   };
 }
 

--- a/frontend/src/test/derivedRates.test.ts
+++ b/frontend/src/test/derivedRates.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { formatValue } from "../utils";
+import { withDerivedRates } from "../data/useData";
+
+describe("formatValue pp format", () => {
+  it("renders a rate difference in percentage points", () => {
+    expect(formatValue(0.0052, "pp")).toBe("0.52pp");
+    expect(formatValue(0, "pp")).toBe("0.00pp");
+    expect(formatValue(null, "pp")).toBe("N/A");
+  });
+});
+
+describe("withDerivedRates", () => {
+  const row = {
+    baseline_poverty_count: 100_000,
+    reform_poverty_count: 110_000,
+    population: 1_000_000,
+    baseline_child_poverty_count: 30_000,
+    reform_child_poverty_count: 36_000,
+    child_population: 300_000,
+  };
+
+  it("derives rates and pp cuts from the weighted counts", () => {
+    const r = withDerivedRates(row);
+    expect(r.baseline_poverty_rate).toBeCloseTo(0.1);
+    expect(r.reform_poverty_rate).toBeCloseTo(0.11);
+    // Repealing the credit raises poverty 10% -> 11%, so the credit cuts
+    // poverty by 1 percentage point (positive = reduction).
+    expect(r.poverty_pp_cut).toBeCloseTo(0.01);
+    expect(r.baseline_child_poverty_rate).toBeCloseTo(0.1);
+    expect(r.reform_child_poverty_rate).toBeCloseTo(0.12);
+    expect(r.child_poverty_pp_cut).toBeCloseTo(0.02);
+  });
+
+  it("returns zero rates for empty populations", () => {
+    const r = withDerivedRates({
+      ...row,
+      population: 0,
+      child_population: 0,
+    });
+    expect(r.baseline_poverty_rate).toBe(0);
+    expect(r.poverty_pp_cut).toBe(0);
+    expect(r.child_poverty_pp_cut).toBe(0);
+  });
+});

--- a/frontend/src/test/types.test.ts
+++ b/frontend/src/test/types.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "vitest";
 import { METRICS, REFORM_TYPES, STATE_NAMES, SUPPORTED_YEARS } from "../types";
 
 describe("METRICS", () => {
-  it("has 3 metrics", () => {
-    expect(METRICS).toHaveLength(3);
+  it("has 5 metrics", () => {
+    expect(METRICS).toHaveLength(5);
   });
 
   it("includes cost metric", () => {
@@ -12,7 +12,7 @@ describe("METRICS", () => {
 
   it("each metric has a format", () => {
     for (const m of METRICS) {
-      expect(["currency", "percent"]).toContain(m.format);
+      expect(["currency", "percent", "pp"]).toContain(m.format);
     }
   });
 });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -10,6 +10,16 @@ export interface StateResult {
   baseline_child_poverty_count: number;
   reform_child_poverty_count: number;
   child_population: number;
+  /** Derived from the count columns (see withDerivedRates): rates as
+   *  fractions of the (child) population, and the credit's effect as a
+   *  percentage-point cut (baseline rate minus reform rate; positive =
+   *  the credit lowers poverty). */
+  baseline_poverty_rate: number;
+  reform_poverty_rate: number;
+  poverty_pp_cut: number;
+  baseline_child_poverty_rate: number;
+  reform_child_poverty_rate: number;
+  child_poverty_pp_cut: number;
 }
 
 export interface DistrictResult {
@@ -26,25 +36,46 @@ export interface DistrictResult {
   baseline_child_poverty_count: number;
   reform_child_poverty_count: number;
   child_population: number;
+  baseline_poverty_rate: number;
+  reform_poverty_rate: number;
+  poverty_pp_cut: number;
+  baseline_child_poverty_rate: number;
+  reform_child_poverty_rate: number;
+  child_poverty_pp_cut: number;
 }
 
-export type MetricKey = "cost" | "poverty_pct_cut" | "child_poverty_pct_cut";
+export type MetricKey =
+  | "cost"
+  | "poverty_pct_cut"
+  | "child_poverty_pct_cut"
+  | "poverty_pp_cut"
+  | "child_poverty_pp_cut";
 
 export type ViewType = "state" | "district";
 
 export interface MetricOption {
   label: string;
   key: MetricKey;
-  format: "currency" | "percent";
+  format: "currency" | "percent" | "pp";
 }
 
 export const METRICS: MetricOption[] = [
   { label: "Total Cost", key: "cost", format: "currency" },
-  { label: "Poverty Reduction", key: "poverty_pct_cut", format: "percent" },
+  { label: "Poverty Reduction (%)", key: "poverty_pct_cut", format: "percent" },
   {
-    label: "Child Poverty Reduction",
+    label: "Child Poverty Reduction (%)",
     key: "child_poverty_pct_cut",
     format: "percent",
+  },
+  {
+    label: "Poverty Rate Change (pp)",
+    key: "poverty_pp_cut",
+    format: "pp",
+  },
+  {
+    label: "Child Poverty Rate Change (pp)",
+    key: "child_poverty_pp_cut",
+    format: "pp",
   },
 ];
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,7 +12,7 @@ export interface StateResult {
   child_population: number;
   /** Derived from the count columns (see withDerivedRates): rates as
    *  fractions of the (child) population, and the credit's effect as a
-   *  percentage-point cut (baseline rate minus reform rate; positive =
+   *  percentage-point cut (repeal rate minus baseline rate; positive =
    *  the credit lowers poverty). */
   baseline_poverty_rate: number;
   reform_poverty_rate: number;

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,6 +1,6 @@
 export function formatValue(
   value: number | null | undefined,
-  format: "currency" | "percent",
+  format: "currency" | "percent" | "pp",
 ): string {
   if (value === null || value === undefined || isNaN(value)) return "N/A";
   if (format === "currency") {
@@ -10,5 +10,7 @@ export function formatValue(
     if (absValue >= 1e3) return "$" + (value / 1e3).toFixed(1) + "K";
     return "$" + value.toFixed(0);
   }
+  // "pp": a rate difference shown in percentage points (0.005 -> "0.50pp").
+  if (format === "pp") return (value * 100).toFixed(2) + "pp";
   return (value * 100).toFixed(2) + "%";
 }


### PR DESCRIPTION
Adds the level view of each credit's poverty impact: baseline/reform poverty and child-poverty **rates** and their **percentage-point change**, alongside the existing percent reductions.

Everything is derived client-side from the weighted count columns the CSVs already carry (`baseline_poverty_count`, `population`, etc.) — **no pipeline or data change**, so this composes with the data refresh @PavelMakarchuk is running.

- `useData` enriches each state/district row with `baseline/reform_poverty_rate`, `poverty_pp_cut` (+ child equivalents). Positive pp cut = the credit lowers poverty, same orientation as `pct_cut`.
- Two new metric options — *Poverty Rate Change (pp)* and *Child Poverty Rate Change (pp)* — flow through the dropdown, choropleth, hover popups, and detail panel via the existing METRICS plumbing.
- Detail panel pp rows show the movement explicitly: "13.10% without → 12.40% with credit".
- Stats banner shows the national rate movement under each reduction stat.
- `formatValue` gains a `"pp"` format; unit tests added for it and the rate derivation.

⚠️ **Heads-up for the data refresh** (@PavelMakarchuk): the `update-eitc-ctc-results-12` branch's CSVs currently use the old 7-column schema without the count/population columns — merging those would break both the existing national stats banner and this PR's rate metrics (they'd read as zero). The rerun pipeline needs to keep emitting `baseline_poverty_count, reform_poverty_count, population, baseline_child_poverty_count, reform_child_poverty_count, child_population`. Also worth bumping its `policyengine-us==1.633.2` pin while rerunning — 1.765.0 is current and includes this year's state credit changes (ID CTC expiry, GA exemption, RI 2027 CTC, MN combined credit fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)